### PR TITLE
feat: Antibiotic Azithromycin with CLSI MICs

### DIFF
--- a/HaemophilusWeb/Controllers/HomeController.cs
+++ b/HaemophilusWeb/Controllers/HomeController.cs
@@ -22,6 +22,7 @@ namespace HaemophilusWeb.Controllers
             },
             new List<Change>
             {
+                new Change(new DateTime(2022, 06, 26), "Azithromycin mit CLSI MHKs", 109, ChangeType.Feature, DatabaseType.Meningococci),
                 new Change(new DateTime(2022, 06, 1), "PubMLST matching mit IRIS Datenbank", 123, ChangeType.Feature, DatabaseType.Meningococci),
                 new Change(new DateTime(2022, 04, 1), "Isolierte DNA wird beim speichern auf 'Nicht angewachsen' zurückgesetzt", 119, ChangeType.Bug, DatabaseType.Meningococci),
                 new Change(new DateTime(2022, 03, 30, 17, 0, 0), "<p>Automatisches setzen der Beurteilung</p>" +

--- a/HaemophilusWeb/Models/EucastClinicalBreakpoint.cs
+++ b/HaemophilusWeb/Models/EucastClinicalBreakpoint.cs
@@ -44,7 +44,7 @@ namespace HaemophilusWeb.Models
             {
                 if (NoEucastAvailable)
                 {
-                    return string.Format("{0} - ohne EUCAST Grenzwerte", AntibioticDetails);
+                    return string.Format("{0} - ohne Grenzwerte", AntibioticDetails);
                 }
                 return string.Format("{0} - v{1} vom {2:dd. MMM. yy}", AntibioticDetails, Version,
                     ValidFrom);

--- a/HaemophilusWeb/Properties/GlobalAssemblyInfo.cs
+++ b/HaemophilusWeb/Properties/GlobalAssemblyInfo.cs
@@ -25,5 +25,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Revision and Build Numbers
 // by using the '*' as shown below:
 
-[assembly: AssemblyVersion("3.21")]
-[assembly: AssemblyFileVersion("3.21")]
+[assembly: AssemblyVersion("3.22")]
+[assembly: AssemblyFileVersion("3.22")]

--- a/HaemophilusWeb/Tools/MeningoSendingLaboratoryExport.cs
+++ b/HaemophilusWeb/Tools/MeningoSendingLaboratoryExport.cs
@@ -75,6 +75,7 @@ namespace HaemophilusWeb.Tools
             AddEpsilometerTestFields(this, Antibiotic.Ciprofloxacin);
             AddEpsilometerTestFields(this, Antibiotic.Rifampicin);
             AddEpsilometerTestFields(this, Antibiotic.Cefotaxime);
+            AddEpsilometerTestFields(this, Antibiotic.Azithromycin);
 
             AddPubMsltProperty("PubMLST ID", _ => _.PubMlstId, "-");
             AddPubMsltProperty("Datenbank", _ => _.Database);

--- a/HaemophilusWeb/Validators/EpsilometerTestValidator.cs
+++ b/HaemophilusWeb/Validators/EpsilometerTestValidator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using FluentValidation;
 using HaemophilusWeb.Models;
@@ -7,8 +8,9 @@ namespace HaemophilusWeb.Validators
 {
     public class EpsilometerTestValidator : AbstractValidator<EpsilometerTestViewModel>
     {
-        public static readonly List<float> AmpicillinAndAmoxicillinClavulanateETestScale = new List<float> { 256, 192, 128, 96, 64, 48, 32, 24, 16, 12, 8, 6, 4, 3, 2, 1.5f, 1.0f, .75f, .50f, .38f, .25f, .19f, .125f, .094f, .064f, .047f, .032f, .023f, .016f };
-        public static readonly List<float> OtherAntibioticsETestScale = new List<float> { 32, 24, 16, 12, 8, 6, 4, 3, 2, 1.5f, 1.0f, .75f, .50f, .38f, .25f, .19f, .125f, .094f, .064f, .047f, .032f, .023f, .016f, .012f, .008f, .006f, .004f, .003f, .002f };
+        public static readonly List<float> AmpicillinAndAmoxicillinClavulanateMhkScale = new List<float> { 256, 192, 128, 96, 64, 48, 32, 24, 16, 12, 8, 6, 4, 3, 2, 1.5f, 1.0f, .75f, .50f, .38f, .25f, .19f, .125f, .094f, .064f, .047f, .032f, .023f, .016f };
+        public static readonly List<float> AzithromycinMhkScale = new List<float> { 16, 8, 4, 2, 1.0f, .50f, .25f, .125f, .06f, .03f };
+        public static readonly List<float> OtherAntibioticsMhkScale = new List<float> { 32, 24, 16, 12, 8, 6, 4, 3, 2, 1.5f, 1.0f, .75f, .50f, .38f, .25f, .19f, .125f, .094f, .064f, .047f, .032f, .023f, .016f, .012f, .008f, .006f, .004f, .003f, .002f };
 
         private const string MeasurementMustBeGreaterThanZero = "'{PropertyName}' muss ein Wert von der E-Test Skala sein.";
         private const string EucastClinicalBreakpointIdIsRequired = "'{PropertyName}' darf nicht leer sein";
@@ -20,11 +22,18 @@ namespace HaemophilusWeb.Validators
             RuleFor(e => e.Antibiotic).Must(BeSetIfMeasurementHasValue).WithMessage(EucastClinicalBreakpointIdIsRequired);
         }
 
-        public static List<float> GetETestScale(Antibiotic? antibiotic)
+        public static List<float> GetMhkScale(Antibiotic? antibiotic)
         {
-            return antibiotic.HasValue && (antibiotic.Value == Antibiotic.Ampicillin || antibiotic.Value == Antibiotic.AmoxicillinClavulanate)
-                ? AmpicillinAndAmoxicillinClavulanateETestScale
-                : OtherAntibioticsETestScale;
+            switch (antibiotic)
+            {
+                case Antibiotic.Ampicillin:
+                case Antibiotic.AmoxicillinClavulanate:
+                    return AmpicillinAndAmoxicillinClavulanateMhkScale;
+                case Antibiotic.Azithromycin:
+                    return AzithromycinMhkScale;
+                default:
+                    return OtherAntibioticsMhkScale;
+            }
         }
 
         private static bool BeSetIfMeasurementHasValue(EpsilometerTestViewModel eTest, int? eucastClinicalBreakpointId)
@@ -42,7 +51,7 @@ namespace HaemophilusWeb.Validators
             bool measurementIsValid = false;
             if (eTest.Antibiotic.HasValue && measurement.HasValue)
             {
-                measurementIsValid = GetETestScale(eTest.Antibiotic.Value).Contains(measurement.Value);
+                measurementIsValid = GetMhkScale(eTest.Antibiotic.Value).Contains(measurement.Value);
             }
             return !measurement.HasValue || measurementIsValid;
         }

--- a/HaemophilusWeb/ViewModels/EpsilometerTestViewModel.cs
+++ b/HaemophilusWeb/ViewModels/EpsilometerTestViewModel.cs
@@ -18,7 +18,7 @@ namespace HaemophilusWeb.ViewModels
         [Display(Name = "Antibiotikum")]
         public Antibiotic? Antibiotic { get; set; }
 
-        [Display(Name = "EUCAST Breakpoint")]
+        [Display(Name = "Breakpoint")]
         public int? EucastClinicalBreakpointId { get; set; }
 
         [Display(Name = "Messwert")]

--- a/HaemophilusWeb/Views/EucastClinicalBreakpoints/Create.cshtml
+++ b/HaemophilusWeb/Views/EucastClinicalBreakpoints/Create.cshtml
@@ -1,7 +1,7 @@
 ﻿@model HaemophilusWeb.Models.EucastClinicalBreakpoint
 
 @{
-    ViewBag.Title = "EUCAST Grenzwert anlegen";
+    ViewBag.Title = "Grenzwert anlegen";
 }
 
 @section CreateModel

--- a/HaemophilusWeb/Views/EucastClinicalBreakpoints/Edit.cshtml
+++ b/HaemophilusWeb/Views/EucastClinicalBreakpoints/Edit.cshtml
@@ -1,7 +1,7 @@
 ﻿@model HaemophilusWeb.Models.EucastClinicalBreakpoint
 
 @{
-    ViewBag.Title = "EUCAST Grenzwert bearbeiten";
+    ViewBag.Title = "Grenzwert bearbeiten";
 }
 
 @section EditModel

--- a/HaemophilusWeb/Views/EucastClinicalBreakpoints/Index.cshtml
+++ b/HaemophilusWeb/Views/EucastClinicalBreakpoints/Index.cshtml
@@ -4,10 +4,10 @@
 @model IEnumerable<HaemophilusWeb.Models.EucastClinicalBreakpoint>
 
 @{
-    ViewBag.Title = "EUCAST Grenzwerte";
+    ViewBag.Title = "Grenzwerte";
 }
 <p>
-    @Html.ActionLink("Neuen EUCAST Grenzwert anlegen", "Create", "EucastClinicalBreakpoints", null, new { @class = "btn btn-primary" })
+    @Html.ActionLink("Neuen Grenzwert anlegen", "Create", "EucastClinicalBreakpoints", null, new { @class = "btn btn-primary" })
 </p>
 <table class="table table-striped" id="eucastClinicalBreakpoints">
     <thead>

--- a/HaemophilusWeb/Views/Shared/EditorTemplates/EpsilometerTestViewModel.cshtml
+++ b/HaemophilusWeb/Views/Shared/EditorTemplates/EpsilometerTestViewModel.cshtml
@@ -7,7 +7,7 @@
 @{ 
     var relevantBreakPoints = ((IEnumerable<EucastClinicalBreakpoint>) ViewBag.ClinicalBreakpoints).Where(
         b => b.Antibiotic == Model.Antibiotic).ToList();
-    var measurements = EpsilometerTestValidator.GetETestScale(Model.Antibiotic);
+    var measurements = EpsilometerTestValidator.GetMhkScale(Model.Antibiotic);
 }
 
 <div class="form-group">
@@ -37,7 +37,7 @@
                 Text = option.ToString(),
                 Value = option.ToString(),
                 Selected = Model != null && option.Equals(Model.Measurement)
-            }), "E-Test Wert auswählen...", new {@class = "form-control"})
+            }), "MHK auswählen...", new {@class = "form-control"})
         @Html.ValidationMessageFor(m => m.Measurement)
     </div>
     <div class="col-sm-4 col-xs-7">
@@ -47,7 +47,7 @@
                 Text = option.Title,
                 Value = option.EucastClinicalBreakpointId.ToString(),
                 Selected = (Model != null) && (option.EucastClinicalBreakpointId == Model.EucastClinicalBreakpointId)
-            }), "EUCAST Breakpoint auswählen...", new { @class = "form-control" })
+            }), "Breakpoint auswählen...", new { @class = "form-control" })
         @Html.ValidationMessageFor(m => m.EucastClinicalBreakpointId)
     </div>
     <div class="col-sm-4 col-xs-2 etest-labels">
@@ -63,13 +63,17 @@
 
 <script>
     function CallChangefunc(val) {
-        var measurements = @Html.Raw(Json.Encode(EpsilometerTestValidator.OtherAntibioticsETestScale));
+        //TODO use a API call instead of reimplementing EpsilometerTestValidator.GetMhkScale
+        var measurements = @Html.Raw(Json.Encode(EpsilometerTestValidator.OtherAntibioticsMhkScale));
         $('#EpsilometerTestViewModels_0__Measurement').children().remove();
         if (val == @Html.Raw((int)Antibiotic.Ampicillin) || val == @Html.Raw((int)Antibiotic.AmoxicillinClavulanate) ) {
-            measurements = @Html.Raw(Json.Encode(EpsilometerTestValidator.AmpicillinAndAmoxicillinClavulanateETestScale));
+            measurements = @Html.Raw(Json.Encode(EpsilometerTestValidator.AmpicillinAndAmoxicillinClavulanateMhkScale));
+        }
+        else if (val == @Html.Raw((int)Antibiotic.Azithromycin) ) {
+            measurements = @Html.Raw(Json.Encode(EpsilometerTestValidator.AzithromycinMhkScale));
         }
 
-        $('<option/>').html("E-Test Wert auswählen...").appendTo('#EpsilometerTestViewModels_0__Measurement');
+        $('<option/>').html("MHK auswählen...").appendTo('#EpsilometerTestViewModels_0__Measurement');
         for (var i = 0; i < measurements.length;i++){
             $('<option/>').val(measurements[i].toLocaleString()).html(measurements[i].toLocaleString()).appendTo('#EpsilometerTestViewModels_0__Measurement');
         }

--- a/HaemophilusWeb/Views/Shared/_Layout.cshtml
+++ b/HaemophilusWeb/Views/Shared/_Layout.cshtml
@@ -64,7 +64,7 @@
                                 <ul class="dropdown-menu" role="menu">
                                     <li>@Html.ActionLink("Gelöschte Einsender", "Deleted", "Sender")</li>
                                     <li>@Html.ActionLink("Gelöschte Einsendungen (Haemophilus)", "Deleted", "PatientSending")</li>
-                                    <li>@Html.ActionLink("EUCAST Grenzwerte", "Index", "EucastClinicalBreakpoints")</li>
+                                    <li>@Html.ActionLink("Antibiotika Grenzwerte", "Index", "EucastClinicalBreakpoints")</li>
                                     <li>@Html.ActionLink("Gesundheitsämter", "Index", "HealthOffices")</li>
                                 </ul>
                             </li>

--- a/HaemophilusWeb/Web.template.config
+++ b/HaemophilusWeb/Web.template.config
@@ -20,7 +20,7 @@
     
     <!-- Input fields for primary antibiotics are always shown if corresponding breakpoints exist -->
     <add key="PrimaryAntibiotics_Haemophilus" value="Ampicillin,Cefotaxime,Imipenem" />
-    <add key="PrimaryAntibiotics_Meningococci" value="Benzylpenicillin,Ciprofloxacin,Rifampicin,Cefotaxime" />
+    <add key="PrimaryAntibiotics_Meningococci" value="Benzylpenicillin,Ciprofloxacin,Rifampicin,Cefotaxime,Azithromycin" />
     
     <!-- Order for antibiotic fields if present (on report/edit mask) -->
     <add key="AntibioticsOrder" value="Ampicillin,AmoxicillinClavulanate,Cefotaxime,Imipenem,Meropenem" />

--- a/HaemophilusWebTests/Tools/MeningoSendingLaboratoryExportTests.cs
+++ b/HaemophilusWebTests/Tools/MeningoSendingLaboratoryExportTests.cs
@@ -39,7 +39,7 @@ namespace HaemophilusWeb.Tools
 
             var export = sut.ToDataTable(Sendings);
 
-            export.Columns.Count.Should().Be(78);
+            export.Columns.Count.Should().Be(80);
         }
 
         [Test]
@@ -279,6 +279,27 @@ namespace HaemophilusWeb.Tools
             export.Rows[0]["Serogruppe"].Should().Be(DBNull.Value);
             export.Rows[0]["Regel"].Should().Be("StemInterpretation_27");
             export.Rows[0]["Meningokokken"].Should().Be("kein Nachweis");
+        }
+
+        [Test]
+        public void DataTable_ContainsMicValues()
+        {
+            var sut = CreateExportDefinition();
+            Sending.Isolate.EpsilometerTests.Clear();
+            Sending.Isolate.EpsilometerTests.Add(Antibiotic.Benzylpenicillin, 2.0f);
+            Sending.Isolate.EpsilometerTests.Add(Antibiotic.Ciprofloxacin, .75f);
+            Sending.Isolate.EpsilometerTests.Add(Antibiotic.Cefotaxime, 1.25f);
+            Sending.Isolate.EpsilometerTests.Add(Antibiotic.Rifampicin, 0.125f);
+            Sending.Isolate.EpsilometerTests.Add(Antibiotic.Azithromycin, 32f);
+
+            var export = sut.ToDataTable(Sendings);
+
+            var row = export.Rows[0];
+            export.Rows[0]["Penicillin MHK"].Should().Be(2.0d);
+            export.Rows[0]["Ciprofloxacin MHK"].Should().Be(.75d);
+            export.Rows[0]["Cefotaxim MHK"].Should().Be(1.25d);
+            export.Rows[0]["Rifampicin MHK"].Should().Be(.125d);
+            export.Rows[0]["Azithromycin MHK"].Should().Be(32d);
         }
 
         private static MeningoSendingLaboratoryExport CreateExportDefinition()

--- a/HaemophilusWebTests/Validators/EpsilometerTestValidatorTest.cs
+++ b/HaemophilusWebTests/Validators/EpsilometerTestValidatorTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using FluentAssertions;
 using HaemophilusWeb.Models;
 using HaemophilusWeb.ViewModels;
 using NUnit.Framework;
@@ -24,6 +25,19 @@ namespace HaemophilusWeb.Validators
                 Antibiotic = Antibiotic.Amikacin,
                 EucastClinicalBreakpointId = 1
             };
+        }
+
+        [TestCase(null, 32f, 256f)]
+        [TestCase(Antibiotic.Aspoxicillin, 32f, 256f)]
+        [TestCase(Antibiotic.Ampicillin, 256f, 0.002f)]
+        [TestCase(Antibiotic.AmoxicillinClavulanate, 256f, 0.002f)]
+        [TestCase(Antibiotic.Azithromycin, 16f, 32f)]
+        public void GetMhkScale_ValidAntibiotic_ReturnsSuitableList(Antibiotic? antibiotic, float contained, float notContained)
+        {
+            var mhkScale = EpsilometerTestValidator.GetMhkScale(antibiotic);
+
+            mhkScale.Should().Contain(contained);
+            mhkScale.Should().NotContain(notContained);
         }
 
         protected static IEnumerable<Tuple<EpsilometerTestViewModel, string[]>> CreateInvalidModels()
@@ -60,6 +74,13 @@ namespace HaemophilusWeb.Validators
                 Measurement = 64.0f, // Value not on E-Test scale for Meropenem
                 EucastClinicalBreakpointId = 1,
                 Antibiotic = Antibiotic.Meropenem,
+            }, new[] { "Measurement" });
+
+            yield return Tuple.Create(new EpsilometerTestViewModel
+            {
+                Measurement = 32.0f, // Value not on E-Test scale for Meropenem
+                EucastClinicalBreakpointId = 1,
+                Antibiotic = Antibiotic.Azithromycin,
             }, new[] { "Measurement" });
         }
     }


### PR DESCRIPTION
Add new default antibiotic for Menigococci. Remove wording of EUCAST
from UI as Azithromycin is evaluated using CLSI. The internal data
structures still fit hence restructuring data can be postponed until
other CSLI MICs are introduced (if ever)

Refs: #109
