### PR TITLE
Improve editing

### DIFF
--- a/HaemophilusWeb/Controllers/HomeController.cs
+++ b/HaemophilusWeb/Controllers/HomeController.cs
@@ -22,6 +22,8 @@ namespace HaemophilusWeb.Controllers
             },
             new List<Change>
             {
+                new Change(new DateTime(2023, 5, 29, 17, 30, 00), "Ausschalten der Autoverfollständigung vom Browser", ChangeType.Feature, DatabaseType.None),
+                new Change(new DateTime(2023, 5, 29, 17, 00, 00), "Geburtsdatum seht initial nicht auf dem aktuellen Datum sondern ist leer", ChangeType.Feature, DatabaseType.None),
                 new Change(new DateTime(2023, 3, 11), "Update Befundvorlagen", ChangeType.Feature, DatabaseType.None),
                 new Change(new DateTime(2023, 2, 19), "Regel NoNM_01 und NoNM_02 wird nicht angewendet", ChangeType.Bug, DatabaseType.Meningococci),
                 new Change(new DateTime(2023, 1, 18, 23, 0, 0), "Korrektur Nativmaterialien- und Teilbefund", ChangeType.Bug, DatabaseType.Meningococci),

--- a/HaemophilusWeb/Views/Shared/_Layout.cshtml
+++ b/HaemophilusWeb/Views/Shared/_Layout.cshtml
@@ -140,20 +140,23 @@
         </div>
 
         
-        <script>
+    <script>
             $(document).ready(function()
             {
                 $(".datepicker").datetimepicker(
                     {
                         format: "DD.MM.YYYY",
                         pickTime: false,
-                        language: "de"
+                        language: "de",
+                        useCurrent: false
                     });
                 $(".datetimepicker").datetimepicker(
                     {
                         format: "DD.MM.YYYY HH:mm",
                         language: "de"
                     });
+                
+                $("input").attr("autocomplete", "new-password");
 
                 // Localization
                 $.when(


### PR DESCRIPTION
- Keep date fields empty per default instead of initializing to now
- Disable browser autocomplete as it overlays the custom
  autofill features (e.g. postal code)
